### PR TITLE
Fix NPE when Polygon below ComposedBlock (ALTO)

### DIFF
--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/sax/SaxPageHandler_Alto_2_1.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/sax/SaxPageHandler_Alto_2_1.java
@@ -999,7 +999,9 @@ public class SaxPageHandler_Alto_2_1 extends SaxPageHandler {
 		}
 		
 		if (polygon.getSize() >= 3)
-			currentRegion.setCoords(polygon);
+			if (currentRegion != null) {
+				currentRegion.setCoords(polygon);
+			}	
 	}
 	
 	/**


### PR DESCRIPTION
When using the Page Viewer with ALTO-XML, I got a NullPointerException when a Shape-element containing a Polygon was located directly below a ComposedBlock-element (which in turn was directly below PrintSpace). In that particular case, currentRegion does not seem to be set at the time the Polygon element is handled. Checking for currentRegion != null seems to fix that problem.
