### PR TITLE
fix newline normalization assignment

### DIFF
--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
@@ -1026,7 +1026,7 @@ public class XmlPageWriter_Alto implements XmlPageWriter {
 					continue;
 				
 				String regionText = textRegion.getText() != null && !textRegion.getText().isEmpty() ? textRegion.getText() : textRegion.composeText(false, true);
-				regionText.replaceAll("\r\n", "\n");
+				regionText = regionText.replaceAll("\r\n", "\n");
 				
 				String[] regionTextSplit = regionText.split("\n");
 				


### PR DESCRIPTION
Unless intended, the replacement of ```\r\n``` with ```\n``` in the regionText is currently ignored (line 1029).
https://github.com/PRImA-Research-Lab/prima-core-libs/blob/d95dc0b6bcc446b38249b844c44031308c0a1e28/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java#L1028-L1029
Assigning the result of the replaceAll() method to the original string would fix this.