### PR TITLE
Add margins for PAGE to ALTO conversion

### DIFF
--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
@@ -450,9 +450,67 @@ public class XmlPageWriter_Alto implements XmlPageWriter {
 		//Styles
 		
 		//TODO: TopMargin, LeftMargin, RightMargin, BottomMargin
+		//Treat everything outside of print space as margin
+		addMargins(pageNode);
+
 
 		//Print space
 		addPrintSpace(pageNode);
+	}
+
+	private void addMargins(Element parent) {
+
+		Element topMarginNode = doc.createElementNS(getNamespace(), AltoXmlNames.ELEMENT_TopMargin);
+		parent.appendChild(topMarginNode);
+		addAttribute(topMarginNode, AltoXmlNames.ATTR_ID, "TopMarginTypeID"+0);
+
+		Element leftMarginNode = doc.createElementNS(getNamespace(), AltoXmlNames.ELEMENT_LeftMargin);
+		parent.appendChild(leftMarginNode);
+		addAttribute(leftMarginNode, AltoXmlNames.ATTR_ID, "LeftMarginTypeID"+0);
+
+		Element rightMarginNode = doc.createElementNS(getNamespace(), AltoXmlNames.ELEMENT_RightMargin);
+		parent.appendChild(rightMarginNode);
+		addAttribute(rightMarginNode, AltoXmlNames.ATTR_ID, "RightMarginTypeID"+0);
+
+		Element bottomMarginNode = doc.createElementNS(getNamespace(), AltoXmlNames.ELEMENT_BottomMargin);
+		parent.appendChild(bottomMarginNode);
+		addAttribute(bottomMarginNode, AltoXmlNames.ATTR_ID, "BottomMarginTypeID"+0);
+
+		if (layout.getPrintSpace() != null) {
+			Rect printSpaceCoords = layout.getPrintSpace().getCoords().getBoundingBox();
+			int height = layout.getHeight()-1;
+			int width = layout.getWidth()-1;
+
+			Polygon topMarginCoords = new Polygon();
+			Polygon leftMarginCoords = new Polygon();
+			Polygon rightMarginCoords = new Polygon();
+			Polygon bottomMarginCoords = new Polygon();
+
+			topMarginCoords.addPoint(0, 0);
+			topMarginCoords.addPoint(width, 0);
+			topMarginCoords.addPoint(width, printSpaceCoords.top-1);
+			topMarginCoords.addPoint(0, printSpaceCoords.top-1);
+
+			bottomMarginCoords.addPoint(0, printSpaceCoords.bottom+1);
+			bottomMarginCoords.addPoint(width, printSpaceCoords.bottom+1);
+			bottomMarginCoords.addPoint(width, height);
+			bottomMarginCoords.addPoint(0, height);
+
+			leftMarginCoords.addPoint(0, topMarginCoords.getBoundingBox().bottom+1);
+			leftMarginCoords.addPoint(printSpaceCoords.left-1, topMarginCoords.getBoundingBox().bottom+1);
+			leftMarginCoords.addPoint(printSpaceCoords.left-1, bottomMarginCoords.getBoundingBox().top-1);
+			leftMarginCoords.addPoint(0, bottomMarginCoords.getBoundingBox().top-1);
+
+			rightMarginCoords.addPoint(printSpaceCoords.right+1, topMarginCoords.getBoundingBox().bottom+1);
+			rightMarginCoords.addPoint(width, topMarginCoords.getBoundingBox().bottom+1);
+			rightMarginCoords.addPoint(width, bottomMarginCoords.getBoundingBox().top-1);
+			rightMarginCoords.addPoint(printSpaceCoords.right+1, bottomMarginCoords.getBoundingBox().top-1);
+
+			addPositionAttributes(topMarginNode, topMarginCoords);
+			addPositionAttributes(leftMarginNode, leftMarginCoords);
+			addPositionAttributes(rightMarginNode, rightMarginCoords);
+			addPositionAttributes(bottomMarginNode, bottomMarginCoords);
+		}
 	}
 	
 	private void addPrintSpace(Element parent) {

--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
@@ -476,41 +476,54 @@ public class XmlPageWriter_Alto implements XmlPageWriter {
 		parent.appendChild(bottomMarginNode);
 		addAttribute(bottomMarginNode, AltoXmlNames.ATTR_ID, "BottomMarginTypeID"+0);
 
+		Rect printSpaceCoords;
+
 		if (layout.getPrintSpace() != null) {
-			Rect printSpaceCoords = layout.getPrintSpace().getCoords().getBoundingBox();
-			int height = layout.getHeight()-1;
-			int width = layout.getWidth()-1;
-
-			Polygon topMarginCoords = new Polygon();
-			Polygon leftMarginCoords = new Polygon();
-			Polygon rightMarginCoords = new Polygon();
-			Polygon bottomMarginCoords = new Polygon();
-
-			topMarginCoords.addPoint(0, 0);
-			topMarginCoords.addPoint(width, 0);
-			topMarginCoords.addPoint(width, printSpaceCoords.top-1);
-			topMarginCoords.addPoint(0, printSpaceCoords.top-1);
-
-			bottomMarginCoords.addPoint(0, printSpaceCoords.bottom+1);
-			bottomMarginCoords.addPoint(width, printSpaceCoords.bottom+1);
-			bottomMarginCoords.addPoint(width, height);
-			bottomMarginCoords.addPoint(0, height);
-
-			leftMarginCoords.addPoint(0, topMarginCoords.getBoundingBox().bottom+1);
-			leftMarginCoords.addPoint(printSpaceCoords.left-1, topMarginCoords.getBoundingBox().bottom+1);
-			leftMarginCoords.addPoint(printSpaceCoords.left-1, bottomMarginCoords.getBoundingBox().top-1);
-			leftMarginCoords.addPoint(0, bottomMarginCoords.getBoundingBox().top-1);
-
-			rightMarginCoords.addPoint(printSpaceCoords.right+1, topMarginCoords.getBoundingBox().bottom+1);
-			rightMarginCoords.addPoint(width, topMarginCoords.getBoundingBox().bottom+1);
-			rightMarginCoords.addPoint(width, bottomMarginCoords.getBoundingBox().top-1);
-			rightMarginCoords.addPoint(printSpaceCoords.right+1, bottomMarginCoords.getBoundingBox().top-1);
-
-			addPositionAttributes(topMarginNode, topMarginCoords);
-			addPositionAttributes(leftMarginNode, leftMarginCoords);
-			addPositionAttributes(rightMarginNode, rightMarginCoords);
-			addPositionAttributes(bottomMarginNode, bottomMarginCoords);
+			printSpaceCoords = layout.getPrintSpace().getCoords().getBoundingBox();
+		}else {
+			Polygon regionPolygons = new Polygon();
+			for (int i = 0; i < layout.getRegionCount(); i++) {
+				Rect regionBoundingBox = layout.getRegion(i).getCoords().getBoundingBox();
+				regionPolygons.addPoint(regionBoundingBox.top, regionBoundingBox.left);
+				regionPolygons.addPoint(regionBoundingBox.top, regionBoundingBox.right);
+				regionPolygons.addPoint(regionBoundingBox.bottom, regionBoundingBox.left);
+				regionPolygons.addPoint(regionBoundingBox.bottom, regionBoundingBox.right);
+			}
+			printSpaceCoords = regionPolygons.getBoundingBox();
 		}
+
+		int height = layout.getHeight()-1;
+		int width = layout.getWidth()-1;
+
+		Polygon topMarginCoords = new Polygon();
+		Polygon leftMarginCoords = new Polygon();
+		Polygon rightMarginCoords = new Polygon();
+		Polygon bottomMarginCoords = new Polygon();
+
+		topMarginCoords.addPoint(0, 0);
+		topMarginCoords.addPoint(width, 0);
+		topMarginCoords.addPoint(width, printSpaceCoords.top-1);
+		topMarginCoords.addPoint(0, printSpaceCoords.top-1);
+
+		bottomMarginCoords.addPoint(0, printSpaceCoords.bottom+1);
+		bottomMarginCoords.addPoint(width, printSpaceCoords.bottom+1);
+		bottomMarginCoords.addPoint(width, height);
+		bottomMarginCoords.addPoint(0, height);
+
+		leftMarginCoords.addPoint(0, topMarginCoords.getBoundingBox().bottom+1);
+		leftMarginCoords.addPoint(printSpaceCoords.left-1, topMarginCoords.getBoundingBox().bottom+1);
+		leftMarginCoords.addPoint(printSpaceCoords.left-1, bottomMarginCoords.getBoundingBox().top-1);
+		leftMarginCoords.addPoint(0, bottomMarginCoords.getBoundingBox().top-1);
+
+		rightMarginCoords.addPoint(printSpaceCoords.right+1, topMarginCoords.getBoundingBox().bottom+1);
+		rightMarginCoords.addPoint(width, topMarginCoords.getBoundingBox().bottom+1);
+		rightMarginCoords.addPoint(width, bottomMarginCoords.getBoundingBox().top-1);
+		rightMarginCoords.addPoint(printSpaceCoords.right+1, bottomMarginCoords.getBoundingBox().top-1);
+
+		addPositionAttributes(topMarginNode, topMarginCoords);
+		addPositionAttributes(leftMarginNode, leftMarginCoords);
+		addPositionAttributes(rightMarginNode, rightMarginCoords);
+		addPositionAttributes(bottomMarginNode, bottomMarginCoords);
 	}
 	
 	private void addPrintSpace(Element parent) {


### PR DESCRIPTION
Adds ALTO margin elements (TopMargin, LeftMargin, RightMargin, BottomMargin) when converting from PAGE XML to ALTO.

When a `PrintSpace` is defined inside PAGE XML, everything outside the `PrintSpace` will get treated as margin (and assigned to the four different margin regions according to the [ALTO definition](https://www.loc.gov/standards/alto/images/margins.gif)).


The fowlloing XML snippet shows the result of such a conversion:
```xml
…
<Page HEIGHT="2686" ID="p0" PAGECLASS="content" PHYSICAL_IMG_NR="0" WIDTH="1700">
    <TopMargin HEIGHT="376" HPOS="0" ID="TopMarginTypeID0" VPOS="0" WIDTH="1700"/>
    <LeftMargin HEIGHT="1772" HPOS="0" ID="LeftMarginTypeID0" VPOS="376" WIDTH="630"/>
    <RightMargin HEIGHT="1772" HPOS="1699" ID="RightMarginTypeID0" VPOS="376" WIDTH="3"/>
    <BottomMargin HEIGHT="538" HPOS="0" ID="BottomMarginTypeID0" VPOS="2148" WIDTH="1700"/>
    <PrintSpace HEIGHT="1772" HPOS="630" ID="PageSpaceTypeID0" VPOS="376" WIDTH="1071">
        <Shape>
            <Polygon POINTS="630,376 1700,376 1700,2147 630,2147"/>
        </Shape>
      …
```

When no `PrintSpace` exists, a bounding box around all regions will get calculated and the margins will get calculated from this bounding box. If this behavior isn't intended I could also offer a pull request without it.