### PR TITLE
Add type to ComposedBlock

### DIFF
--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
@@ -498,7 +498,7 @@ public class XmlPageWriter_Alto implements XmlPageWriter {
 		
 		Element blockNode = doc.createElementNS(getNamespace(), getAltoBlockType(region));
 
-		if(getAltoBlockType(region) == "ComposedBlock") {
+		if(getAltoBlockType(region).equals("ComposedBlock")) {
 			//Type (use PAGE region type)
 			addAttribute(blockNode, AltoXmlNames.ATTR_TYPE, region.getType().toString());
 		}

--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
@@ -497,6 +497,12 @@ public class XmlPageWriter_Alto implements XmlPageWriter {
 	void addBlock(Element parent, Region region) {
 		
 		Element blockNode = doc.createElementNS(getNamespace(), getAltoBlockType(region));
+
+		if(getAltoBlockType(region) == "ComposedBlock") {
+			//Type (use PAGE region type)
+			addAttribute(blockNode, AltoXmlNames.ATTR_TYPE, region.getType().toString());
+		}
+
 		parent.appendChild(blockNode);
 
 		//ID


### PR DESCRIPTION
Adds the PAGE XML region type to created `ComposedBlockType`-Elements (akin to how `IllustrationBlock`-Elements are already converted).

Example:
```xml
    <ComposedBlock HEIGHT="86" HPOS="25" ID="r_200" TAGREFS="tag2" TYPE="TableRegion"
                VPOS="475" WIDTH="376">
        <Shape>
            <Polygon POINTS="25,475 25,560 400,560 400,475"/>
        </Shape>
        <TextBlock HEIGHT="86" HPOS="25" ID="r_200_1" VPOS="475" WIDTH="376">
        …
    </ComposedBlock>
```