### PR TITLE
Replace string comparisons with Map

### DIFF
--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
@@ -27,6 +27,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -824,196 +826,197 @@ public class XmlPageWriter_Alto implements XmlPageWriter {
 	}
 	
 	String getAltoLanguage(String pageLanguage) {
-		if ("Abkhaz".equals(pageLanguage)) return "ab";
-		if ("Afar".equals(pageLanguage)) return "aa";
-		if ("Afrikaans".equals(pageLanguage)) return "af";
-		if ("Akan".equals(pageLanguage)) return "ak";
-		if ("Albanian".equals(pageLanguage)) return "sq";
-		if ("Amharic".equals(pageLanguage)) return "am";
-		if ("Arabic".equals(pageLanguage)) return "ar";
-		if ("Aragonese".equals(pageLanguage)) return "an";
-		if ("Armenian".equals(pageLanguage)) return "hy";
-		if ("Assamese".equals(pageLanguage)) return "as";
-		if ("Avaric".equals(pageLanguage)) return "av";
-		if ("Avestan".equals(pageLanguage)) return "ae";
-		if ("Aymara".equals(pageLanguage)) return "ay";
-		if ("Azerbaijani".equals(pageLanguage)) return "az";
-		if ("Bambara".equals(pageLanguage)) return "bm";
-		if ("Bashkir".equals(pageLanguage)) return "ba";
-		if ("Basque".equals(pageLanguage)) return "eu";
-		if ("Belarusian".equals(pageLanguage)) return "be";
-		if ("Bengali".equals(pageLanguage)) return "bn";
-		if ("Bihari".equals(pageLanguage)) return "bh";
-		if ("Bislama".equals(pageLanguage)) return "bi";
-		if ("Bosnian".equals(pageLanguage)) return "bs";
-		if ("Breton".equals(pageLanguage)) return "br";
-		if ("Bulgarian".equals(pageLanguage)) return "bg";
-		if ("Burmese".equals(pageLanguage)) return "my";
-		if ("Cambodian".equals(pageLanguage)) return "km";
-		if ("Catalan".equals(pageLanguage)) return "ca";
-		if ("Chamorro".equals(pageLanguage)) return "ch";
-		if ("Chechen".equals(pageLanguage)) return "ce";
-		if ("Chichewa".equals(pageLanguage)) return "ny";
-		if ("Chinese".equals(pageLanguage)) return "zh";
-		if ("Chuvash".equals(pageLanguage)) return "cv";
-		if ("Cornish".equals(pageLanguage)) return "kw";
-		if ("Corsican".equals(pageLanguage)) return "co";
-		if ("Cree".equals(pageLanguage)) return "cr";
-		if ("Croatian".equals(pageLanguage)) return "hr";
-		if ("Czech".equals(pageLanguage)) return "cs";
-		if ("Danish".equals(pageLanguage)) return "da";
-		if ("Divehi".equals(pageLanguage)) return "dv";
-		if ("Dutch".equals(pageLanguage)) return "nl";
-		if ("Dzongkha".equals(pageLanguage)) return "dz";
-		if ("English".equals(pageLanguage)) return "en";
-		if ("English".equals(pageLanguage)) return "en";
-		if ("English".equals(pageLanguage)) return "en";
-		if ("Esperanto".equals(pageLanguage)) return "eo";
-		if ("Estonian".equals(pageLanguage)) return "et";
-		if ("Ewe".equals(pageLanguage)) return "ee";
-		if ("Faroese".equals(pageLanguage)) return "fo";
-		if ("Fijian".equals(pageLanguage)) return "fj";
-		if ("Finnish".equals(pageLanguage)) return "fi";
-		if ("French".equals(pageLanguage)) return "fr";
-		if ("Fula".equals(pageLanguage)) return "ff";
-		if ("Gaelic".equals(pageLanguage)) return "gd";
-		if ("Galician".equals(pageLanguage)) return "gl";
-		if ("Ganda".equals(pageLanguage)) return "lg";
-		if ("Georgian".equals(pageLanguage)) return "ka";
-		if ("German".equals(pageLanguage)) return "de";
-		if ("Greek".equals(pageLanguage)) return "el";
-		if ("Guaraní".equals(pageLanguage)) return "gn";
-		if ("Gujarati".equals(pageLanguage)) return "gu";
-		if ("Haitian".equals(pageLanguage)) return "ht";
-		if ("Hausa".equals(pageLanguage)) return "ha";
-		if ("Hebrew".equals(pageLanguage)) return "he";
-		if ("Herero".equals(pageLanguage)) return "hz";
-		if ("Hindi".equals(pageLanguage)) return "hi";
-		if ("Hiri Motu".equals(pageLanguage)) return "ho";
-		if ("Hungarian".equals(pageLanguage)) return "hu";
-		if ("Icelandic".equals(pageLanguage)) return "is";
-		if ("Ido".equals(pageLanguage)) return "io";
-		if ("Igbo".equals(pageLanguage)) return "ig";
-		if ("Indonesian".equals(pageLanguage)) return "id";
-		if ("Interlingua".equals(pageLanguage)) return "ia";
-		if ("Interlingue".equals(pageLanguage)) return "ie";
-		if ("Inuktitut".equals(pageLanguage)) return "iu";
-		if ("Inupiaq".equals(pageLanguage)) return "ik";
-		if ("Irish".equals(pageLanguage)) return "ga";
-		if ("Italian".equals(pageLanguage)) return "it";
-		if ("Japanese".equals(pageLanguage)) return "ja";
-		if ("Javanese".equals(pageLanguage)) return "jv";
-		if ("Kalaallisut".equals(pageLanguage)) return "kl";
-		if ("Kannada".equals(pageLanguage)) return "kn";
-		if ("Kanuri".equals(pageLanguage)) return "kr";
-		if ("Kashmiri".equals(pageLanguage)) return "ks";
-		if ("Kazakh".equals(pageLanguage)) return "kk";
-		if ("Khmer".equals(pageLanguage)) return "km";
-		if ("Kikuyu".equals(pageLanguage)) return "ki";
-		if ("Kinyarwanda".equals(pageLanguage)) return "rw";
-		if ("Kirundi".equals(pageLanguage)) return "rn";
-		if ("Komi".equals(pageLanguage)) return "kv";
-		if ("Kongo".equals(pageLanguage)) return "kg";
-		if ("Korean".equals(pageLanguage)) return "ko";
-		if ("Kurdish".equals(pageLanguage)) return "ku";
-		if ("Kwanyama".equals(pageLanguage)) return "kj";
-		if ("Kyrgyz".equals(pageLanguage)) return "ky";
-		if ("Lao".equals(pageLanguage)) return "lo";
-		if ("Latin".equals(pageLanguage)) return "la";
-		if ("Latvian".equals(pageLanguage)) return "lv";
-		if ("Limburgish".equals(pageLanguage)) return "li";
-		if ("Lingala".equals(pageLanguage)) return "ln";
-		if ("Lithuanian".equals(pageLanguage)) return "lt";
-		if ("Luba-Katanga".equals(pageLanguage)) return "lu";
-		if ("Luxembourgish".equals(pageLanguage)) return "lb";
-		if ("Macedonian".equals(pageLanguage)) return "mk";
-		if ("Malagasy".equals(pageLanguage)) return "mg";
-		if ("Malay".equals(pageLanguage)) return "ms";
-		if ("Malayalam".equals(pageLanguage)) return "ml";
-		if ("Maltese".equals(pageLanguage)) return "mt";
-		if ("Manx".equals(pageLanguage)) return "gv";
-		if ("Māori".equals(pageLanguage)) return "mi";
-		if ("Marathi".equals(pageLanguage)) return "mr";
-		if ("Marshallese".equals(pageLanguage)) return "mh";
-		if ("Mongolian".equals(pageLanguage)) return "mn";
-		if ("Nauru".equals(pageLanguage)) return "na";
-		if ("Navajo".equals(pageLanguage)) return "nv";
-		if ("Ndonga".equals(pageLanguage)) return "ng";
-		if ("Nepali".equals(pageLanguage)) return "ne";
-		if ("North Ndebele".equals(pageLanguage)) return "nd";
-		if ("Northern Sami".equals(pageLanguage)) return "se";
-		if ("Norwegian".equals(pageLanguage)) return "no";
-		if ("Norwegian Bokmål".equals(pageLanguage)) return "nb";
-		if ("Norwegian Nynorsk".equals(pageLanguage)) return "nn";
-		if ("Nuosu".equals(pageLanguage)) return "ii";
-		if ("Occitan".equals(pageLanguage)) return "oc";
-		if ("Ojibwe".equals(pageLanguage)) return "oj";
-		if ("Old Church Slavonic".equals(pageLanguage)) return "cu";
-		if ("Oriya".equals(pageLanguage)) return "or";
-		if ("Oromo".equals(pageLanguage)) return "om";
-		if ("Ossetian".equals(pageLanguage)) return "os";
-		if ("Pāli".equals(pageLanguage)) return "pi";
-		if ("Panjabi".equals(pageLanguage)) return "pa";
-		if ("Pashto".equals(pageLanguage)) return "ps";
-		if ("Persian".equals(pageLanguage)) return "fa";
-		if ("Polish".equals(pageLanguage)) return "pl";
-		if ("Portuguese".equals(pageLanguage)) return "pt";
-		if ("Punjabi".equals(pageLanguage)) return "pa";
-		if ("Quechua".equals(pageLanguage)) return "qu";
-		if ("Romanian".equals(pageLanguage)) return "ro";
-		if ("Romansh".equals(pageLanguage)) return "rm";
-		if ("Russian".equals(pageLanguage)) return "ru";
-		if ("Samoan".equals(pageLanguage)) return "sm";
-		if ("Sango".equals(pageLanguage)) return "sg";
-		if ("Sanskrit".equals(pageLanguage)) return "sa";
-		if ("Sardinian".equals(pageLanguage)) return "sc";
-		if ("Serbian".equals(pageLanguage)) return "sr";
-		if ("Shona".equals(pageLanguage)) return "sn";
-		if ("Sindhi".equals(pageLanguage)) return "sd";
-		if ("Sinhala".equals(pageLanguage)) return "si";
-		if ("Slovak".equals(pageLanguage)) return "sk";
-		if ("Slovene".equals(pageLanguage)) return "sl";
-		if ("Somali".equals(pageLanguage)) return "so";
-		if ("South Ndebele".equals(pageLanguage)) return "nr";
-		if ("Southern Sotho".equals(pageLanguage)) return "st";
-		if ("Spanish".equals(pageLanguage)) return "es";
-		if ("Sundanese".equals(pageLanguage)) return "su";
-		if ("Swahili".equals(pageLanguage)) return "sw";
-		if ("Swati".equals(pageLanguage)) return "ss";
-		if ("Swedish".equals(pageLanguage)) return "sv";
-		if ("Tagalog".equals(pageLanguage)) return "tl";
-		if ("Tahitian".equals(pageLanguage)) return "ty";
-		if ("Tajik".equals(pageLanguage)) return "tg";
-		if ("Tamil".equals(pageLanguage)) return "ta";
-		if ("Tatar".equals(pageLanguage)) return "tt";
-		if ("Telugu".equals(pageLanguage)) return "te";
-		if ("Thai".equals(pageLanguage)) return "th";
-		if ("Tibetan".equals(pageLanguage)) return "bo";
-		if ("Tigrinya".equals(pageLanguage)) return "ti";
-		if ("Tonga".equals(pageLanguage)) return "to";
-		if ("Tsonga".equals(pageLanguage)) return "ts";
-		if ("Tswana".equals(pageLanguage)) return "tn";
-		if ("Turkish".equals(pageLanguage)) return "tr";
-		if ("Turkmen".equals(pageLanguage)) return "tk";
-		if ("Twi".equals(pageLanguage)) return "tw";
-		if ("Uighur".equals(pageLanguage)) return "ug";
-		if ("Ukrainian".equals(pageLanguage)) return "uk";
-		if ("Urdu".equals(pageLanguage)) return "ur";
-		if ("Uzbek".equals(pageLanguage)) return "uz";
-		if ("Venda".equals(pageLanguage)) return "ve";
-		if ("Vietnamese".equals(pageLanguage)) return "vi";
-		if ("Volapük".equals(pageLanguage)) return "vo";
-		if ("Walloon".equals(pageLanguage)) return "wa";
-		if ("Welsh".equals(pageLanguage)) return "cy";
-		if ("Western Frisian".equals(pageLanguage)) return "fy";
-		if ("Wolof".equals(pageLanguage)) return "wo";
-		if ("Xhosa".equals(pageLanguage)) return "xh";
-		if ("Yiddish".equals(pageLanguage)) return "yi";
-		if ("Yoruba".equals(pageLanguage)) return "yo";
-		if ("Zhuang".equals(pageLanguage)) return "za";
-		if ("Zulu".equals(pageLanguage)) return "zu";
+		Map<String, String> AltoLanguages = Stream.of(new String[][] {
+			{"Abkhaz", "ab"},
+			{"Afar", "aa"},
+			{"Afrikaans", "af"},
+			{"Akan", "ak"},
+			{"Albanian", "sq"},
+			{"Amharic", "am"},
+			{"Arabic", "ar"},
+			{"Aragonese", "an"},
+			{"Armenian", "hy"},
+			{"Assamese", "as"},
+			{"Avaric", "av"},
+			{"Avestan", "ae"},
+			{"Aymara", "ay"},
+			{"Azerbaijani", "az"},
+			{"Bambara", "bm"},
+			{"Bashkir", "ba"},
+			{"Basque", "eu"},
+			{"Belarusian", "be"},
+			{"Bengali", "bn"},
+			{"Bihari", "bh"},
+			{"Bislama", "bi"},
+			{"Bosnian", "bs"},
+			{"Breton", "br"},
+			{"Bulgarian", "bg"},
+			{"Burmese", "my"},
+			{"Cambodian", "km"},
+			{"Catalan", "ca"},
+			{"Chamorro", "ch"},
+			{"Chechen", "ce"},
+			{"Chichewa", "ny"},
+			{"Chinese", "zh"},
+			{"Chuvash", "cv"},
+			{"Cornish", "kw"},
+			{"Corsican", "co"},
+			{"Cree", "cr"},
+			{"Croatian", "hr"},
+			{"Czech", "cs"},
+			{"Danish", "da"},
+			{"Divehi", "dv"},
+			{"Dutch", "nl"},
+			{"Dzongkha", "dz"},
+			{"English", "en"},
+			{"English", "en"},
+			{"Esperanto", "eo"},
+			{"Estonian", "et"},
+			{"Ewe", "ee"},
+			{"Faroese", "fo"},
+			{"Fijian", "fj"},
+			{"Finnish", "fi"},
+			{"French", "fr"},
+			{"Fula", "ff"},
+			{"Gaelic", "gd"},
+			{"Galician", "gl"},
+			{"Ganda", "lg"},
+			{"Georgian", "ka"},
+			{"German", "de"},
+			{"Greek", "el"},
+			{"Guaraní", "gn"},
+			{"Gujarati", "gu"},
+			{"Haitian", "ht"},
+			{"Hausa", "ha"},
+			{"Hebrew", "he"},
+			{"Herero", "hz"},
+			{"Hindi", "hi"},
+			{"Hiri Motu", "ho"},
+			{"Hungarian", "hu"},
+			{"Icelandic", "is"},
+			{"Ido", "io"},
+			{"Igbo", "ig"},
+			{"Indonesian", "id"},
+			{"Interlingua", "ia"},
+			{"Interlingue", "ie"},
+			{"Inuktitut", "iu"},
+			{"Inupiaq", "ik"},
+			{"Irish", "ga"},
+			{"Italian", "it"},
+			{"Japanese", "ja"},
+			{"Javanese", "jv"},
+			{"Kalaallisut", "kl"},
+			{"Kannada", "kn"},
+			{"Kanuri", "kr"},
+			{"Kashmiri", "ks"},
+			{"Kazakh", "kk"},
+			{"Khmer", "km"},
+			{"Kikuyu", "ki"},
+			{"Kinyarwanda", "rw"},
+			{"Kirundi", "rn"},
+			{"Komi", "kv"},
+			{"Kongo", "kg"},
+			{"Korean", "ko"},
+			{"Kurdish", "ku"},
+			{"Kwanyama", "kj"},
+			{"Kyrgyz", "ky"},
+			{"Lao", "lo"},
+			{"Latin", "la"},
+			{"Latvian", "lv"},
+			{"Limburgish", "li"},
+			{"Lingala", "ln"},
+			{"Lithuanian", "lt"},
+			{"Luba-Katanga", "lu"},
+			{"Luxembourgish", "lb"},
+			{"Macedonian", "mk"},
+			{"Malagasy", "mg"},
+			{"Malay", "ms"},
+			{"Malayalam", "ml"},
+			{"Maltese", "mt"},
+			{"Manx", "gv"},
+			{"Māori", "mi"},
+			{"Marathi", "mr"},
+			{"Marshallese", "mh"},
+			{"Mongolian", "mn"},
+			{"Nauru", "na"},
+			{"Navajo", "nv"},
+			{"Ndonga", "ng"},
+			{"Nepali", "ne"},
+			{"North Ndebele", "nd"},
+			{"Northern Sami", "se"},
+			{"Norwegian", "no"},
+			{"Norwegian Bokmål", "nb"},
+			{"Norwegian Nynorsk", "nn"},
+			{"Nuosu", "ii"},
+			{"Occitan", "oc"},
+			{"Ojibwe", "oj"},
+			{"Old Church Slavonic", "cu"},
+			{"Oriya", "or"},
+			{"Oromo", "om"},
+			{"Ossetian", "os"},
+			{"Pāli", "pi"},
+			{"Panjabi", "pa"},
+			{"Pashto", "ps"},
+			{"Persian", "fa"},
+			{"Polish", "pl"},
+			{"Portuguese", "pt"},
+			{"Punjabi", "pa"},
+			{"Quechua", "qu"},
+			{"Romanian", "ro"},
+			{"Romansh", "rm"},
+			{"Russian", "ru"},
+			{"Samoan", "sm"},
+			{"Sango", "sg"},
+			{"Sanskrit", "sa"},
+			{"Sardinian", "sc"},
+			{"Serbian", "sr"},
+			{"Shona", "sn"},
+			{"Sindhi", "sd"},
+			{"Sinhala", "si"},
+			{"Slovak", "sk"},
+			{"Slovene", "sl"},
+			{"Somali", "so"},
+			{"South Ndebele", "nr"},
+			{"Southern Sotho", "st"},
+			{"Spanish", "es"},
+			{"Sundanese", "su"},
+			{"Swahili", "sw"},
+			{"Swati", "ss"},
+			{"Swedish", "sv"},
+			{"Tagalog", "tl"},
+			{"Tahitian", "ty"},
+			{"Tajik", "tg"},
+			{"Tamil", "ta"},
+			{"Tatar", "tt"},
+			{"Telugu", "te"},
+			{"Thai", "th"},
+			{"Tibetan", "bo"},
+			{"Tigrinya", "ti"},
+			{"Tonga", "to"},
+			{"Tsonga", "ts"},
+			{"Tswana", "tn"},
+			{"Turkish", "tr"},
+			{"Turkmen", "tk"},
+			{"Twi", "tw"},
+			{"Uighur", "ug"},
+			{"Ukrainian", "uk"},
+			{"Urdu", "ur"},
+			{"Uzbek", "uz"},
+			{"Venda", "ve"},
+			{"Vietnamese", "vi"},
+			{"Volapük", "vo"},
+			{"Walloon", "wa"},
+			{"Welsh", "cy"},
+			{"Western Frisian", "fy"},
+			{"Wolof", "wo"},
+			{"Xhosa", "xh"},
+			{"Yiddish", "yi"},
+			{"Yoruba", "yo"},
+			{"Zhuang", "za"},
+			{"Zulu", "zu"}
+		}).collect(Collectors.toMap(data -> data[0], data -> data[1]));
 
-		return null;
+		return AltoLanguages.get(pageLanguage);
 	}
 	
 	//Propagate text from regions to words / glyphs

--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageWriter_Alto.java
@@ -869,7 +869,6 @@ public class XmlPageWriter_Alto implements XmlPageWriter {
 			{"Dutch", "nl"},
 			{"Dzongkha", "dz"},
 			{"English", "en"},
-			{"English", "en"},
 			{"Esperanto", "eo"},
 			{"Estonian", "et"},
 			{"Ewe", "ee"},

--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/sax/SaxPageHandler_Alto_2_1.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/sax/SaxPageHandler_Alto_2_1.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.primaresearch.dla.page.Page;
 import org.primaresearch.dla.page.Page.MeasurementUnit;
@@ -657,198 +659,199 @@ public class SaxPageHandler_Alto_2_1 extends SaxPageHandler {
 	}
 	
 	private String altoToPrimaLanguage(String altoLanguageValue) {
-		if ("ab".equals(altoLanguageValue)) return "Abkhaz";
-		if ("aa".equals(altoLanguageValue)) return "Afar";
-		if ("af".equals(altoLanguageValue)) return "Afrikaans";
-		if ("ak".equals(altoLanguageValue)) return "Akan";
-		if ("sq".equals(altoLanguageValue)) return "Albanian";
-		if ("am".equals(altoLanguageValue)) return "Amharic";
-		if ("ar".equals(altoLanguageValue)) return "Arabic";
-		if ("an".equals(altoLanguageValue)) return "Aragonese";
-		if ("hy".equals(altoLanguageValue)) return "Armenian";
-		if ("as".equals(altoLanguageValue)) return "Assamese";
-		if ("av".equals(altoLanguageValue)) return "Avaric";
-		if ("ae".equals(altoLanguageValue)) return "Avestan";
-		if ("ay".equals(altoLanguageValue)) return "Aymara";
-		if ("az".equals(altoLanguageValue)) return "Azerbaijani";
-		if ("bm".equals(altoLanguageValue)) return "Bambara";
-		if ("ba".equals(altoLanguageValue)) return "Bashkir";
-		if ("eu".equals(altoLanguageValue)) return "Basque";
-		if ("be".equals(altoLanguageValue)) return "Belarusian";
-		if ("bn".equals(altoLanguageValue)) return "Bengali";
-		if ("bh".equals(altoLanguageValue)) return "Bihari";
-		if ("bi".equals(altoLanguageValue)) return "Bislama";
-		if ("bs".equals(altoLanguageValue)) return "Bosnian";
-		if ("br".equals(altoLanguageValue)) return "Breton";
-		if ("bg".equals(altoLanguageValue)) return "Bulgarian";
-		if ("my".equals(altoLanguageValue)) return "Burmese";
-		if ("km".equals(altoLanguageValue)) return "Cambodian";
-		//if ("".equals(altoLanguageValue)) return "Cantonese";
-		if ("ca".equals(altoLanguageValue)) return "Catalan";
-		if ("ch".equals(altoLanguageValue)) return "Chamorro";
-		if ("ce".equals(altoLanguageValue)) return "Chechen";
-		if ("ny".equals(altoLanguageValue)) return "Chichewa";
-		if ("zh".equals(altoLanguageValue)) return "Chinese";
-		if ("cv".equals(altoLanguageValue)) return "Chuvash";
-		if ("kw".equals(altoLanguageValue)) return "Cornish";
-		if ("co".equals(altoLanguageValue)) return "Corsican";
-		if ("cr".equals(altoLanguageValue)) return "Cree";
-		if ("hr".equals(altoLanguageValue)) return "Croatian";
-		if ("cs".equals(altoLanguageValue)) return "Czech";
-		if ("da".equals(altoLanguageValue)) return "Danish";
-		if ("dv".equals(altoLanguageValue)) return "Divehi";
-		if ("nl".equals(altoLanguageValue)) return "Dutch";
-		if ("dz".equals(altoLanguageValue)) return "Dzongkha";
-		if ("en".equals(altoLanguageValue)) return "English";
-		if ("en-GB".equals(altoLanguageValue)) return "English";
-		if ("en-US".equals(altoLanguageValue)) return "English";
-		if ("eo".equals(altoLanguageValue)) return "Esperanto";
-		if ("et".equals(altoLanguageValue)) return "Estonian";
-		if ("ee".equals(altoLanguageValue)) return "Ewe";
-		if ("fo".equals(altoLanguageValue)) return "Faroese";
-		if ("fj".equals(altoLanguageValue)) return "Fijian";
-		if ("fi".equals(altoLanguageValue)) return "Finnish";
-		if ("fr".equals(altoLanguageValue)) return "French";
-		if ("ff".equals(altoLanguageValue)) return "Fula";
-		if ("gd".equals(altoLanguageValue)) return "Gaelic";
-		if ("gl".equals(altoLanguageValue)) return "Galician";
-		if ("lg".equals(altoLanguageValue)) return "Ganda";
-		if ("ka".equals(altoLanguageValue)) return "Georgian";
-		if ("de".equals(altoLanguageValue)) return "German";
-		if ("el".equals(altoLanguageValue)) return "Greek";
-		if ("gn".equals(altoLanguageValue)) return "Guaraní";
-		if ("gu".equals(altoLanguageValue)) return "Gujarati";
-		if ("ht".equals(altoLanguageValue)) return "Haitian";
-		if ("ha".equals(altoLanguageValue)) return "Hausa";
-		if ("he".equals(altoLanguageValue)) return "Hebrew";
-		if ("hz".equals(altoLanguageValue)) return "Herero";
-		if ("hi".equals(altoLanguageValue)) return "Hindi";
-		if ("ho".equals(altoLanguageValue)) return "Hiri Motu";
-		if ("hu".equals(altoLanguageValue)) return "Hungarian";
-		if ("is".equals(altoLanguageValue)) return "Icelandic";
-		if ("io".equals(altoLanguageValue)) return "Ido";
-		if ("ig".equals(altoLanguageValue)) return "Igbo";
-		if ("id".equals(altoLanguageValue)) return "Indonesian";
-		if ("ia".equals(altoLanguageValue)) return "Interlingua";
-		if ("ie".equals(altoLanguageValue)) return "Interlingue";
-		if ("iu".equals(altoLanguageValue)) return "Inuktitut";
-		if ("ik".equals(altoLanguageValue)) return "Inupiaq";
-		if ("ga".equals(altoLanguageValue)) return "Irish";
-		if ("it".equals(altoLanguageValue)) return "Italian";
-		if ("ja".equals(altoLanguageValue)) return "Japanese";
-		if ("jv".equals(altoLanguageValue)) return "Javanese";
-		if ("kl".equals(altoLanguageValue)) return "Kalaallisut";
-		if ("kn".equals(altoLanguageValue)) return "Kannada";
-		if ("kr".equals(altoLanguageValue)) return "Kanuri";
-		if ("ks".equals(altoLanguageValue)) return "Kashmiri";
-		if ("kk".equals(altoLanguageValue)) return "Kazakh";
-		if ("km".equals(altoLanguageValue)) return "Khmer";
-		if ("ki".equals(altoLanguageValue)) return "Kikuyu";
-		if ("rw".equals(altoLanguageValue)) return "Kinyarwanda";
-		if ("rn".equals(altoLanguageValue)) return "Kirundi";
-		if ("kv".equals(altoLanguageValue)) return "Komi";
-		if ("kg".equals(altoLanguageValue)) return "Kongo";
-		if ("ko".equals(altoLanguageValue)) return "Korean";
-		if ("ku".equals(altoLanguageValue)) return "Kurdish";
-		if ("kj".equals(altoLanguageValue)) return "Kwanyama";
-		if ("ky".equals(altoLanguageValue)) return "Kyrgyz";
-		if ("lo".equals(altoLanguageValue)) return "Lao";
-		if ("la".equals(altoLanguageValue)) return "Latin";
-		if ("lv".equals(altoLanguageValue)) return "Latvian";
-		if ("li".equals(altoLanguageValue)) return "Limburgish";
-		if ("ln".equals(altoLanguageValue)) return "Lingala";
-		if ("lt".equals(altoLanguageValue)) return "Lithuanian";
-		if ("lu".equals(altoLanguageValue)) return "Luba-Katanga";
-		if ("lb".equals(altoLanguageValue)) return "Luxembourgish";
-		if ("mk".equals(altoLanguageValue)) return "Macedonian";
-		if ("mg".equals(altoLanguageValue)) return "Malagasy";
-		if ("ms".equals(altoLanguageValue)) return "Malay";
-		if ("ml".equals(altoLanguageValue)) return "Malayalam";
-		if ("mt".equals(altoLanguageValue)) return "Maltese";
-		if ("gv".equals(altoLanguageValue)) return "Manx";
-		if ("mi".equals(altoLanguageValue)) return "Māori";
-		if ("mr".equals(altoLanguageValue)) return "Marathi";
-		if ("mh".equals(altoLanguageValue)) return "Marshallese";
-		if ("mn".equals(altoLanguageValue)) return "Mongolian";
-		if ("na".equals(altoLanguageValue)) return "Nauru";
-		if ("nv".equals(altoLanguageValue)) return "Navajo";
-		if ("ng".equals(altoLanguageValue)) return "Ndonga";
-		if ("ne".equals(altoLanguageValue)) return "Nepali";
-		if ("nd".equals(altoLanguageValue)) return "North Ndebele";
-		if ("se".equals(altoLanguageValue)) return "Northern Sami";
-		if ("no".equals(altoLanguageValue)) return "Norwegian";
-		if ("nb".equals(altoLanguageValue)) return "Norwegian Bokmål";
-		if ("nn".equals(altoLanguageValue)) return "Norwegian Nynorsk";
-		if ("ii".equals(altoLanguageValue)) return "Nuosu";
-		if ("oc".equals(altoLanguageValue)) return "Occitan";
-		if ("oj".equals(altoLanguageValue)) return "Ojibwe";
-		if ("cu".equals(altoLanguageValue)) return "Old Church Slavonic";
-		if ("or".equals(altoLanguageValue)) return "Oriya";
-		if ("om".equals(altoLanguageValue)) return "Oromo";
-		if ("os".equals(altoLanguageValue)) return "Ossetian";
-		if ("pi".equals(altoLanguageValue)) return "Pāli";
-		if ("pa".equals(altoLanguageValue)) return "Panjabi";
-		if ("ps".equals(altoLanguageValue)) return "Pashto";
-		if ("fa".equals(altoLanguageValue)) return "Persian";
-		if ("pl".equals(altoLanguageValue)) return "Polish";
-		if ("pt".equals(altoLanguageValue)) return "Portuguese";
-		if ("pa".equals(altoLanguageValue)) return "Punjabi";
-		if ("qu".equals(altoLanguageValue)) return "Quechua";
-		if ("ro".equals(altoLanguageValue)) return "Romanian";
-		if ("rm".equals(altoLanguageValue)) return "Romansh";
-		if ("ru".equals(altoLanguageValue)) return "Russian";
-		if ("sm".equals(altoLanguageValue)) return "Samoan";
-		if ("sg".equals(altoLanguageValue)) return "Sango";
-		if ("sa".equals(altoLanguageValue)) return "Sanskrit";
-		if ("sc".equals(altoLanguageValue)) return "Sardinian";
-		if ("sr".equals(altoLanguageValue)) return "Serbian";
-		if ("sn".equals(altoLanguageValue)) return "Shona";
-		if ("sd".equals(altoLanguageValue)) return "Sindhi";
-		if ("si".equals(altoLanguageValue)) return "Sinhala";
-		if ("sk".equals(altoLanguageValue)) return "Slovak";
-		if ("sl".equals(altoLanguageValue)) return "Slovene";
-		if ("so".equals(altoLanguageValue)) return "Somali";
-		if ("nr".equals(altoLanguageValue)) return "South Ndebele";
-		if ("st".equals(altoLanguageValue)) return "Southern Sotho";
-		if ("es".equals(altoLanguageValue)) return "Spanish";
-		if ("su".equals(altoLanguageValue)) return "Sundanese";
-		if ("sw".equals(altoLanguageValue)) return "Swahili";
-		if ("ss".equals(altoLanguageValue)) return "Swati";
-		if ("sv".equals(altoLanguageValue)) return "Swedish";
-		if ("tl".equals(altoLanguageValue)) return "Tagalog";
-		if ("ty".equals(altoLanguageValue)) return "Tahitian";
-		if ("tg".equals(altoLanguageValue)) return "Tajik";
-		if ("ta".equals(altoLanguageValue)) return "Tamil";
-		if ("tt".equals(altoLanguageValue)) return "Tatar";
-		if ("te".equals(altoLanguageValue)) return "Telugu";
-		if ("th".equals(altoLanguageValue)) return "Thai";
-		if ("bo".equals(altoLanguageValue)) return "Tibetan";
-		if ("ti".equals(altoLanguageValue)) return "Tigrinya";
-		if ("to".equals(altoLanguageValue)) return "Tonga";
-		if ("ts".equals(altoLanguageValue)) return "Tsonga";
-		if ("tn".equals(altoLanguageValue)) return "Tswana";
-		if ("tr".equals(altoLanguageValue)) return "Turkish";
-		if ("tk".equals(altoLanguageValue)) return "Turkmen";
-		if ("tw".equals(altoLanguageValue)) return "Twi";
-		if ("ug".equals(altoLanguageValue)) return "Uighur";
-		if ("uk".equals(altoLanguageValue)) return "Ukrainian";
-		if ("ur".equals(altoLanguageValue)) return "Urdu";
-		if ("uz".equals(altoLanguageValue)) return "Uzbek";
-		if ("ve".equals(altoLanguageValue)) return "Venda";
-		if ("vi".equals(altoLanguageValue)) return "Vietnamese";
-		if ("vo".equals(altoLanguageValue)) return "Volapük";
-		if ("wa".equals(altoLanguageValue)) return "Walloon";
-		if ("cy".equals(altoLanguageValue)) return "Welsh";
-		if ("fy".equals(altoLanguageValue)) return "Western Frisian";
-		if ("wo".equals(altoLanguageValue)) return "Wolof";
-		if ("xh".equals(altoLanguageValue)) return "Xhosa";
-		if ("yi".equals(altoLanguageValue)) return "Yiddish";
-		if ("yo".equals(altoLanguageValue)) return "Yoruba";
-		if ("za".equals(altoLanguageValue)) return "Zhuang";
-		if ("zu".equals(altoLanguageValue)) return "Zulu";
-		if (!altoLanguageValue.isEmpty()) return "other";
+		Map<String, String> PrimaLanguage = Stream.of(new String[][] {
+			{"ab", "Abkhaz"},
+			{"aa", "Afar"},
+			{"af", "Afrikaans"},
+			{"ak", "Akan"},
+			{"sq", "Albanian"},
+			{"am", "Amharic"},
+			{"ar", "Arabic"},
+			{"an", "Aragonese"},
+			{"hy", "Armenian"},
+			{"as", "Assamese"},
+			{"av", "Avaric"},
+			{"ae", "Avestan"},
+			{"ay", "Aymara"},
+			{"az", "Azerbaijani"},
+			{"bm", "Bambara"},
+			{"ba", "Bashkir"},
+			{"eu", "Basque"},
+			{"be", "Belarusian"},
+			{"bn", "Bengali"},
+			{"bh", "Bihari"},
+			{"bi", "Bislama"},
+			{"bs", "Bosnian"},
+			{"br", "Breton"},
+			{"bg", "Bulgarian"},
+			{"my", "Burmese"},
+			{"km", "Cambodian"},
+			//{"", "Cantonese"},
+			{"ca", "Catalan"},
+			{"ch", "Chamorro"},
+			{"ce", "Chechen"},
+			{"ny", "Chichewa"},
+			{"zh", "Chinese"},
+			{"cv", "Chuvash"},
+			{"kw", "Cornish"},
+			{"co", "Corsican"},
+			{"cr", "Cree"},
+			{"hr", "Croatian"},
+			{"cs", "Czech"},
+			{"da", "Danish"},
+			{"dv", "Divehi"},
+			{"nl", "Dutch"},
+			{"dz", "Dzongkha"},
+			{"en", "English"},
+			{"en-GB", "English"},
+			{"en-US", "English"},
+			{"eo", "Esperanto"},
+			{"et", "Estonian"},
+			{"ee", "Ewe"},
+			{"fo", "Faroese"},
+			{"fj", "Fijian"},
+			{"fi", "Finnish"},
+			{"fr", "French"},
+			{"ff", "Fula"},
+			{"gd", "Gaelic"},
+			{"gl", "Galician"},
+			{"lg", "Ganda"},
+			{"ka", "Georgian"},
+			{"de", "German"},
+			{"el", "Greek"},
+			{"gn", "Guaraní"},
+			{"gu", "Gujarati"},
+			{"ht", "Haitian"},
+			{"ha", "Hausa"},
+			{"he", "Hebrew"},
+			{"hz", "Herero"},
+			{"hi", "Hindi"},
+			{"ho", "Hiri Motu"},
+			{"hu", "Hungarian"},
+			{"is", "Icelandic"},
+			{"io", "Ido"},
+			{"ig", "Igbo"},
+			{"id", "Indonesian"},
+			{"ia", "Interlingua"},
+			{"ie", "Interlingue"},
+			{"iu", "Inuktitut"},
+			{"ik", "Inupiaq"},
+			{"ga", "Irish"},
+			{"it", "Italian"},
+			{"ja", "Japanese"},
+			{"jv", "Javanese"},
+			{"kl", "Kalaallisut"},
+			{"kn", "Kannada"},
+			{"kr", "Kanuri"},
+			{"ks", "Kashmiri"},
+			{"kk", "Kazakh"},
+			{"ki", "Kikuyu"},
+			{"rw", "Kinyarwanda"},
+			{"rn", "Kirundi"},
+			{"kv", "Komi"},
+			{"kg", "Kongo"},
+			{"ko", "Korean"},
+			{"ku", "Kurdish"},
+			{"kj", "Kwanyama"},
+			{"ky", "Kyrgyz"},
+			{"lo", "Lao"},
+			{"la", "Latin"},
+			{"lv", "Latvian"},
+			{"li", "Limburgish"},
+			{"ln", "Lingala"},
+			{"lt", "Lithuanian"},
+			{"lu", "Luba-Katanga"},
+			{"lb", "Luxembourgish"},
+			{"mk", "Macedonian"},
+			{"mg", "Malagasy"},
+			{"ms", "Malay"},
+			{"ml", "Malayalam"},
+			{"mt", "Maltese"},
+			{"gv", "Manx"},
+			{"mi", "Māori"},
+			{"mr", "Marathi"},
+			{"mh", "Marshallese"},
+			{"mn", "Mongolian"},
+			{"na", "Nauru"},
+			{"nv", "Navajo"},
+			{"ng", "Ndonga"},
+			{"ne", "Nepali"},
+			{"nd", "North Ndebele"},
+			{"se", "Northern Sami"},
+			{"no", "Norwegian"},
+			{"nb", "Norwegian Bokmål"},
+			{"nn", "Norwegian Nynorsk"},
+			{"ii", "Nuosu"},
+			{"oc", "Occitan"},
+			{"oj", "Ojibwe"},
+			{"cu", "Old Church Slavonic"},
+			{"or", "Oriya"},
+			{"om", "Oromo"},
+			{"os", "Ossetian"},
+			{"pi", "Pāli"},
+			{"pa", "Panjabi"},
+			{"ps", "Pashto"},
+			{"fa", "Persian"},
+			{"pl", "Polish"},
+			{"pt", "Portuguese"},
+			{"qu", "Quechua"},
+			{"ro", "Romanian"},
+			{"rm", "Romansh"},
+			{"ru", "Russian"},
+			{"sm", "Samoan"},
+			{"sg", "Sango"},
+			{"sa", "Sanskrit"},
+			{"sc", "Sardinian"},
+			{"sr", "Serbian"},
+			{"sn", "Shona"},
+			{"sd", "Sindhi"},
+			{"si", "Sinhala"},
+			{"sk", "Slovak"},
+			{"sl", "Slovene"},
+			{"so", "Somali"},
+			{"nr", "South Ndebele"},
+			{"st", "Southern Sotho"},
+			{"es", "Spanish"},
+			{"su", "Sundanese"},
+			{"sw", "Swahili"},
+			{"ss", "Swati"},
+			{"sv", "Swedish"},
+			{"tl", "Tagalog"},
+			{"ty", "Tahitian"},
+			{"tg", "Tajik"},
+			{"ta", "Tamil"},
+			{"tt", "Tatar"},
+			{"te", "Telugu"},
+			{"th", "Thai"},
+			{"bo", "Tibetan"},
+			{"ti", "Tigrinya"},
+			{"to", "Tonga"},
+			{"ts", "Tsonga"},
+			{"tn", "Tswana"},
+			{"tr", "Turkish"},
+			{"tk", "Turkmen"},
+			{"tw", "Twi"},
+			{"ug", "Uighur"},
+			{"uk", "Ukrainian"},
+			{"ur", "Urdu"},
+			{"uz", "Uzbek"},
+			{"ve", "Venda"},
+			{"vi", "Vietnamese"},
+			{"vo", "Volapük"},
+			{"wa", "Walloon"},
+			{"cy", "Welsh"},
+			{"fy", "Western Frisian"},
+			{"wo", "Wolof"},
+			{"xh", "Xhosa"},
+			{"yi", "Yiddish"},
+			{"yo", "Yoruba"},
+			{"za", "Zhuang"},
+			{"zu", "Zulu"}
+		}).collect(Collectors.toMap(data -> data[0], data -> data[1]));
 
-		return null;	
+		if(altoLanguageValue != null)
+			return PrimaLanguage.getOrDefault(altoLanguageValue, "other");
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Replaces the string comparisons for converting between Prima and Alto language names with a Map for improved readability and probably some speed improvements (which are probably neglectable though).
Also removes a duplicate entry ("English -> en" appeared twice).