### PR TITLE
PAGE reader: throw error msg

### DIFF
--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageReader.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageReader.java
@@ -143,8 +143,10 @@ public class XmlPageReader extends PageReaderBase implements PageReader {
 		
 		Page page = null;
 		
-		if (!lastErrors.hasErrors())
-			page = pageHandler.getPageObject();
+		if (lastErrors.hasErrors())
+			throw new UnsupportedFormatVersionException(getErrors().toString());
+
+		page = pageHandler.getPageObject();
 		
 		//if (!MeasurementUnit.PIXEL.equals(pageHandler.getMeasurementUnit()))
 			

--- a/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageReader.java
+++ b/java/PrimaDla/src/org/primaresearch/dla/page/io/xml/XmlPageReader.java
@@ -143,8 +143,12 @@ public class XmlPageReader extends PageReaderBase implements PageReader {
 		
 		Page page = null;
 		
-		if (lastErrors.hasErrors())
-			throw new UnsupportedFormatVersionException(getErrors().toString());
+		if (lastErrors.hasErrors()) {
+			StringBuilder sb = new StringBuilder();
+			for (IOError error : getErrors())
+				sb.append(error.getMessage());
+			throw new UnsupportedFormatVersionException(sb.toString());
+		}
 
 		page = pageHandler.getPageObject();
 		


### PR DESCRIPTION
fixes #12 

example (from PageViewer):
```
org.primaresearch.io.UnsupportedFormatVersionException: cvc-id.1: There is no ID/IDREF binding for IDREF 'OCR-D-CLIP_Ansiedlung_Korotschin_UZS_Sign_22a_0000_region0039'.
	at org.primaresearch.dla.page.io.xml.XmlPageReader.read(XmlPageReader.java:150)
	at org.primaresearch.dla.page.io.xml.PageXmlInputOutput.readPage(PageXmlInputOutput.java:224)
	at org.primaresearch.page.viewer.dla.XmlDocumentLayoutLoader.doRun(XmlDocumentLayoutLoader.java:49)
	at org.primaresearch.page.viewer.extra.Task.run(Task.java:49)
	at org.primaresearch.page.viewer.extra.Task$TaskThread.run(Task.java:105)
```
